### PR TITLE
Bumps gitops-repo module to 1.5.0 to handle clis better

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ module setup_clis {
 }
 
 module "gitops-repo" {
-  source = "github.com/cloud-native-toolkit/terraform-tools-git-repo.git?ref=v1.4.1"
+  source = "github.com/cloud-native-toolkit/terraform-tools-git-repo.git?ref=v1.5.0"
 
   host  = var.host
   type  = var.type


### PR DESCRIPTION
Signed-off-by: Sean Sundberg <seansund@us.ibm.com>