### PR TITLE
Bumps gitops-repo to v1.5.2 to handle delete

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ module setup_clis {
 }
 
 module "gitops-repo" {
-  source = "github.com/cloud-native-toolkit/terraform-tools-git-repo.git?ref=v1.5.0"
+  source = "github.com/cloud-native-toolkit/terraform-tools-git-repo.git?ref=v1.5.2"
 
   host  = var.host
   type  = var.type


### PR DESCRIPTION
Signed-off-by: Cloud-Native Toolkit <cloudnativetoolkit@gmail.com>