### PR TITLE
Adds `gitops_repo` alias to module metadata

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -1,4 +1,5 @@
 name: gitops-repo
+alias: gitops_repo
 type: terraform
 description: Module to provision and set up a GitOps repository
 tags:


### PR DESCRIPTION
Linux systems won't allow environment variables that include dashes (`-`) in the name. Iascable will generate variable names prefixed with the module name.

Closes #49