### PR TITLE
Adds test to conditionally initialize the repository

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ module setup_clis {
 }
 
 module "gitops-repo" {
-  source = "github.com/cloud-native-toolkit/terraform-tools-git-repo.git?ref=v1.6.1"
+  source = "github.com/cloud-native-toolkit/terraform-tools-git-repo.git?ref=v1.6.2"
 
   host  = var.host
   type  = var.type
@@ -78,8 +78,6 @@ module "gitops-repo" {
 }
 
 resource null_resource initialize_gitops {
-  count = var.provision || var.initialize ? 1 : 0
-
   provisioner "local-exec" {
     command = "${path.module}/scripts/initialize-gitops.sh '${module.gitops-repo.repo}' '${var.gitops_namespace}' '${var.server_name}'"
 

--- a/scripts/initialize-gitops.sh
+++ b/scripts/initialize-gitops.sh
@@ -25,6 +25,11 @@ git clone "https://${TOKEN}@${REPO}" .tmpgitops
 
 cd .tmpgitops || exit 1
 
+if [[ -f config.yaml ]]; then
+  echo "Repository already initialized. Nothing to do"
+  exit 0
+fi
+
 export BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 cp -R "${TEMPLATE_DIR}"/* .

--- a/variables.tf
+++ b/variables.tf
@@ -24,18 +24,6 @@ variable "branch" {
   default     = "main"
 }
 
-variable "provision" {
-  type        = bool
-  description = "Flag indicating that the git repo should be provisioned. If `false` then the repo is expected to already exist"
-  default     = true
-}
-
-variable "initialize" {
-  type        = bool
-  description = "Flag indicating that the git repo should be initialized. If `false` then the repo is expected to already have been initialized"
-  default     = false
-}
-
 variable "username" {
   type        = string
   description = "The username of the user with access to the repository"


### PR DESCRIPTION
- Removes unnecessary provision and initialize input variables
- Adds check for config.yaml file in the gitops repo before initializing. If the file exists then initialization is skipped
- Bumps git-repo submodule to v1.6.2

Closes #53

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>