### PR TITLE
Adds support for additional git servers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,6 @@
 
 locals {
   bin_dir = module.setup_clis.bin_dir
-  git_org = var.org != null && var.org != "" ? var.org : var.username
   bootstrap_path = "argocd/0-bootstrap/cluster/${var.server_name}"
   cert_file = "${path.cwd}/.tmp/gitops/kubeseal_cert.pem"
   gitops_config = {
@@ -59,6 +58,14 @@ locals {
     username = var.username
     token = var.token
   }]
+
+  git_default = var.host != "" && var.username != "" && var.token != ""
+  tmp_org = local.git_default ? var.org : var.gitea_org
+
+  host = local.git_default ? var.host : var.gitea_host
+  org = local.tmp_org != "" ? local.tmp_org : local.username
+  username = local.git_default ? var.username : var.gitea_username
+  token = local.git_default ? var.token : var.gitea_token
 }
 
 module setup_clis {
@@ -67,14 +74,13 @@ module setup_clis {
 }
 
 module "gitops-repo" {
-  source = "github.com/cloud-native-toolkit/terraform-tools-git-repo.git?ref=v1.6.3"
+  source = "github.com/cloud-native-toolkit/terraform-tools-git-repo.git?ref=v2.0.0"
 
-  host  = var.host
-  type  = var.type
-  org   = local.git_org
+  host  = local.host
+  org   = local.org
   repo  = var.repo
-  token = var.token
-  branch = var.branch
+  username = local.username
+  token = local.token
   public = var.public
   strict = var.strict
 }

--- a/module.yaml
+++ b/module.yaml
@@ -14,9 +14,30 @@ versions:
       refs:
         - source: github.com/cloud-native-toolkit/terraform-util-sealed-secret-cert
           version: ">= 1.0.0"
+    - id: gitea
+      optional: true
+      refs:
+        - source: github.com/cloud-native-toolkit/terraform-tools-gitea
+          version: ">= 0.3.0"
   variables:
     - name: sealed_secrets_cert
       moduleRef:
         id: cert
         output: cert
+    - name: gitea_host
+      moduleRef:
+        id: gitea
+        output: host
+    - name: gitea_org
+      moduleRef:
+        id: gitea
+        output: org
+    - name: gitea_username
+      moduleRef:
+        id: gitea
+        output: username
+    - name: gitea_token
+      moduleRef:
+        id: gitea
+        output: password
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,7 +12,7 @@ output "config_repo_url" {
 }
 
 output "config_username" {
-  value       = var.username
+  value       = module.gitops-repo.username
   description = "The username for the config repo"
   depends_on = [null_resource.initialize_gitops]
 }

--- a/test/stages/stage-gitops.tf
+++ b/test/stages/stage-gitops.tf
@@ -2,7 +2,6 @@ module "gitops" {
   source = "./module"
 
   host = var.git_host
-  type = var.git_type
   org  = ""
   repo = var.git_repo
   token = var.git_token

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,57 @@
 variable "host" {
   type        = string
   description = "The host for the git repository."
+  default     = ""
 }
 
 variable "type" {
   type        = string
-  description = "The type of the hosted git repository (github or gitlab)."
+  description = "[Deprecated] The type of the hosted git repository."
+  default     = ""
 }
 
 variable "org" {
   type        = string
   description = "The org/group where the git repository exists/will be provisioned."
+  default     = ""
+}
+
+variable "username" {
+  type        = string
+  description = "The username of the user with access to the repository"
+  default     = ""
+}
+
+variable "token" {
+  type        = string
+  description = "The personal access token used to access the repository"
+  sensitive   = true
+  default     = ""
+}
+
+variable "gitea_host" {
+  type        = string
+  description = "The host for the git repository."
+  default     = ""
+}
+
+variable "gitea_org" {
+  type        = string
+  description = "The org/group where the git repository exists/will be provisioned."
+  default     = ""
+}
+
+variable "gitea_username" {
+  type        = string
+  description = "The username of the user with access to the repository"
+  default     = ""
+}
+
+variable "gitea_token" {
+  type        = string
+  description = "The personal access token used to access the repository"
+  sensitive   = true
+  default     = ""
 }
 
 variable "repo" {
@@ -22,17 +63,6 @@ variable "branch" {
   type        = string
   description = "The name of the branch that will be used. If the repo already exists (provision=false) then it is assumed this branch already exists as well"
   default     = "main"
-}
-
-variable "username" {
-  type        = string
-  description = "The username of the user with access to the repository"
-}
-
-variable "token" {
-  type        = string
-  description = "The personal access token used to access the repository"
-  sensitive   = true
 }
 
 variable "public" {


### PR DESCRIPTION
- Updates git-repo submodule to v2.0.0 to pick up support for additional git servers - closes #61
- Cleans up input variables
- Adds support for optional gitea repo as default if values not provided

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>