### PR TITLE
Fixes issue with credentials for gitea repo

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,8 +56,8 @@ locals {
   git_credentials = [{
     repo = module.gitops-repo.repo
     url = module.gitops-repo.url
-    username = var.username
-    token = var.token
+    username = module.gitops-repo.username
+    token = module.gitops-repo.token
   }]
 
   git_default = var.host == "" || var.username == "" || var.token == ""

--- a/outputs.tf
+++ b/outputs.tf
@@ -51,9 +51,9 @@ output "config_token" {
 output "config_paths" {
   description = "The paths in the config repo"
   value = {
-    infrastructure = "argocd/1-infrastructure/active"
-    services       = "argocd/2-services/active"
-    applications   = "argocd/3-applications/active"
+    infrastructure = "argocd/1-infrastructure"
+    services       = "argocd/2-services"
+    applications   = "argocd/3-applications"
   }
   depends_on = [null_resource.initialize_gitops]
 }
@@ -93,7 +93,7 @@ output "application_repo_url" {
 }
 
 output "application_username" {
-  value       = var.username
+  value       = module.gitops-repo.username
   description = "The username for the application repo"
   depends_on = [null_resource.initialize_gitops]
 }


### PR DESCRIPTION
- Updates git_credentials object to use username and token from the gitops-repo submodule output to guarantee correct ones are used

closes #81

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>